### PR TITLE
adding JenkinsShowLastBuildLog and JenkinsRebuild

### DIFF
--- a/doc/jenkins.txt
+++ b/doc/jenkins.txt
@@ -22,6 +22,16 @@ Interact with your jenkins instance via its API from within vim.
                               /my/hot/path/without/buildNumber), this will grab the
                               current status of your build from the jenkins API.
 
+:JenkinsShowLastBuildLog      After you've documented your build plan path in a
+                              comment in your Jenkinsfile (// BUILD_PLAN:
+                              /my/hot/path/without/buildNumber), this will show log
+                              of the last build from jenkins.
+
+:JenkinsRebuild               After you've documented your build plan path in a
+                              comment in your Jenkinsfile (// BUILD_PLAN:
+                              /my/hot/path/without/buildNumber), this will rebuild
+                              the specified build number.
+
 ABOUT                                           *jenkins-about*
 
 Grab the latest version or report a bug on GitHub:


### PR DESCRIPTION
Hi Kevin,

This pull-request provides following features:

1. JenkinsRebuild (this is possible thanks to nirzari : https://github.com/nirzari/groovy-scripts/blob/master/rebuild.groovy)
- rebuilds provided build number (provided as parameter)
- rebuild achieved by accessing g:jenkins_url . '/scriptText' URL with slightly modified nirzari's groovy script as data payload (list iteration removed, rebuilding only one build number)
- groovy script has to be written to /tmp/rebuild.groovy before it can be passed to curl
- validation of build number input parameter is performed, only digits allowed

 rebuild path passed to script is collected from chomped l:findBuildPlanCommand (e.g. /job/jobName - where first occurance of '*job/' is being removed)

I had opportunity to test it with simple case:  /job/jobName
Not tested:  /job/someDir/jobName

2. JenkinsShowLastBuildLog
- echoes output of curl '/lastBuild/consoleText' on jenkins server
-  shortcut: <Leader>jl

Could you please review and merge if acceptable?

Regards,
Ivan